### PR TITLE
CI: checkout@v6, Pillow>=12.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
         working-directory: MLService
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -52,7 +52,7 @@ jobs:
         working-directory: Backend
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Swift
         uses: swift-actions/setup-swift@v2
@@ -60,7 +60,7 @@ jobs:
           swift-version: "5.9"
 
       - name: Cache SwiftPM
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: Backend/.build
           key: ${{ runner.os }}-swiftpm-${{ hashFiles('Backend/Package.swift', 'Backend/Package.resolved') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master, develop]
+  pull_request:
+    branches: [main, master, develop]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  mlservice-tests:
+    name: MLService (Python ${{ matrix.python-version }}, pytest)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    defaults:
+      run:
+        working-directory: MLService
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: MLService/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest
+
+      - name: Run tests
+        run: python -m pytest tests/ -v --tb=short
+
+  backend-build:
+    name: Backend (Swift build)
+    runs-on: macos-14
+    defaults:
+      run:
+        working-directory: Backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "5.9"
+
+      - name: Cache SwiftPM
+        uses: actions/cache@v4
+        with:
+          path: Backend/.build
+          key: ${{ runner.os }}-swiftpm-${{ hashFiles('Backend/Package.swift', 'Backend/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swiftpm-
+
+      - name: Build
+        run: swift build -v

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,31 @@
+name: Security
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  pip-audit-mlservice:
+    name: pip-audit (MLService)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: MLService/requirements.txt
+
+      - name: Install pip-audit
+        run: python -m pip install --upgrade pip pip-audit
+
+      - name: Audit requirements
+        working-directory: MLService
+        run: pip-audit -r requirements.txt --desc on

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip

--- a/MLService/requirements.txt
+++ b/MLService/requirements.txt
@@ -9,7 +9,7 @@ opencv-python>=4.10.0
 # Py 3.14 + macOS arm64: torch 2.9.x wheels were missing libtorch_cpu.dylib; use 2.11+
 torch>=2.11.0
 torchvision>=0.26.0
-Pillow>=11.0.0
+Pillow>=12.1.1
 pydantic>=2.9.0
 aiofiles>=24.1.0
 scipy>=1.14.0


### PR DESCRIPTION
## Изменения

- **GitHub Actions:** `actions/checkout@v6` в `ci.yml` и `security.yml` (актуальная линия под Node 24).
- **Зависимости:** `Pillow>=12.1.1` в `MLService/requirements.txt` — закрыт Dependabot alert по PSD (out-of-bounds write).

Прочие локальные правки в репозитории **не входят** в этот коммит.

Made with [Cursor](https://cursor.com)